### PR TITLE
Secure against cross frame scripting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,19 @@ module.exports = withPrefresh({
     }
 
     return config;
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY'
+          }
+        ]
+      }
+    ];
   }
 });
 // module.exports = {


### PR DESCRIPTION
Secures against cross-frame scripting attacks. Embedding temporaldotio in an iFrame is not going to work anymore

Testing:
- Temporaldotio is running under http://localhost:3000
- Then second test app - under http://localhost:3001, test code

```
function App() {
  return (
    <div className="App">
      <header className="App-header">
      <iframe
          src="http://localhost:3000/"
      </header>
    </div>
  );
}
```

![image](https://user-images.githubusercontent.com/11838981/104668813-a4313d80-568d-11eb-8dea-a5be38a31de6.png)
