### PR TITLE
Unpinning the docs nav link to a specific page

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const links = [
   { href: 'https://docs.temporal.io/blog', label: 'Blog' },
-  { href: 'https://docs.temporal.io/docs/concept-overview', label: 'Docs' },
+  { href: 'https://docs.temporal.io/', label: 'Docs' },
   { href: 'https://github.com/temporalio/temporal/', label: 'GitHub' },
   { href: '/careers', label: 'Jobs' },
   { href: 'https://community.temporal.io/', label: 'Community' }


### PR DESCRIPTION
This link should just point at the docs and then allow the docs site to decide what the default is.

I don't link that this was pointing at the concepts overview page -