### PR TITLE
fixing color labels

### DIFF
--- a/pages/press.js
+++ b/pages/press.js
@@ -197,15 +197,15 @@ export default function PressPage() {
             </li>
             <li>
               <div className="border border-white bg-orange2 p-16"></div>
-              <span>Temporal Orange 2 #FFA280</span>
+              <span>Temporal Orange 2 #FF7065</span>
             </li>
             <li>
               <div className="border border-white bg-green1 p-16"></div>
-              <span>Temporal Green 1 #FFA280</span>
+              <span>Temporal Green 1 #9EE587</span>
             </li>
             <li>
               <div className="border border-white bg-green2 p-16"></div>
-              <span>Temporal Green 2 #FFA280</span>
+              <span>Temporal Green 2 #32D67B</span>
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Looks like a copy paste oversight on the labels of the colors on the press page.
<img width="1282" alt="Screen Shot 2021-09-13 at 8 51 03 AM" src="https://user-images.githubusercontent.com/34380806/133107303-1894a558-5a82-4f98-83a7-2858302519cd.png">

Fixed using colors from css:
<img width="274" alt="Screen Shot 2021-09-13 at 8 59 18 AM" src="https://user-images.githubusercontent.com/34380806/133107591-ae936e51-e546-464f-9d9c-9d32e297e335.png">
